### PR TITLE
'Offset' and 'length' arguments added to fincore method

### DIFF
--- a/ftools.c
+++ b/ftools.c
@@ -5,17 +5,22 @@
 #include <linux/fadvise.h>
 #include <sys/syscall.h>
 
-static PyObject *ftools_fincore(PyObject *self, PyObject *args) {
+static PyObject *ftools_fincore(PyObject *self, PyObject *args, PyObject *keywds) {
     PyObject *ret;
     int fd;
+    unsigned long offset = 0;
+    unsigned long length = 0;
     void *file_mmap;
     unsigned char *mincore_vec;
     struct stat file_stat;
     ssize_t page_size = getpagesize();
     ssize_t vec_size;
 
-    if(!PyArg_ParseTuple(args, "i", &fd)) {
-        return NULL;
+    static char *kwlist[] = {"fd", "offset", "length", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "i|kk", kwlist, 
+                                     &fd, &offset, &length)) {
+        return NULL; 
     }
 
     if(fstat(fd, &file_stat) < 0) {
@@ -28,21 +33,24 @@ static PyObject *ftools_fincore(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    file_mmap = mmap((void *)0, file_stat.st_size, PROT_NONE, MAP_SHARED, fd, 0);
+    if ( length == 0 )
+        length = file_stat.st_size - offset;
+
+    file_mmap = mmap((void *)0, length, PROT_NONE, MAP_SHARED, fd, offset);
 
     if(file_mmap == MAP_FAILED) {
         PyErr_SetString(PyExc_IOError, "Could not mmap file");
         return NULL;
     }
 
-    vec_size = (file_stat.st_size + page_size - 1) / page_size;
+    vec_size = (length + page_size - 1) / page_size;
     mincore_vec = calloc(1, vec_size);
 
     if(mincore_vec == NULL) {
         return PyErr_NoMemory();
     }
 
-    if(mincore(file_mmap, file_stat.st_size, mincore_vec) != 0) {
+    if(mincore(file_mmap, length, mincore_vec) != 0) {
         PyErr_SetFromErrno(PyExc_OSError);
         PyErr_SetString(PyExc_OSError, "Could not call mincore for file");
         return NULL;
@@ -50,7 +58,7 @@ static PyObject *ftools_fincore(PyObject *self, PyObject *args) {
 
     ret = Py_BuildValue("s#", mincore_vec, vec_size);
     free(mincore_vec);
-    munmap(file_mmap, file_stat.st_size);
+    munmap(file_mmap, length);
     return ret;
 }
 
@@ -176,7 +184,7 @@ static PyObject *ftools_fadvise(PyObject *self, PyObject *args, PyObject *keywds
 }
 
 static PyMethodDef FtoolsMethods[] = {
-    {"fincore", ftools_fincore, METH_VARARGS, "Return the mincore structure for the given file."},
+    {"fincore", ftools_fincore, METH_KEYWORDS, "Return the mincore structure for the given file."},
     {"fincore_ratio", ftools_fincore_ratio, METH_VARARGS, "Return a int two tuple indicating file in page cache ratio."},
     {"fadvise", (PyCFunction) ftools_fadvise, METH_KEYWORDS, "fadvise system call for Python!"},
     {NULL, NULL, 0, NULL}


### PR DESCRIPTION
mmap call begins at offset bytes and maps length bytes. Offset defaults
to zero (start of file). A length of 0 will mmap the entire file minus
the offset value. Length also defaults to zero, therefore, the behavior
should stay the same for any legacy users.

This makes this the fincore method much more usable for large files - parts of the file can be queried piece-wise to improve responsiveness.
